### PR TITLE
Feature/rest api route

### DIFF
--- a/core/server/api.js
+++ b/core/server/api.js
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { Restivus } from 'meteor/nimble:restivus';
 
 const ApiV1 = new Restivus({
-  apiPath: 'rest-api',
+  apiPath: 'api',
   version: 'v1',
   defaultHeaders: {
     'Content-Type': 'application/json',

--- a/core/server/api.js
+++ b/core/server/api.js
@@ -19,7 +19,7 @@ ApiV1.swagger = {
     swagger: '2.0',
     info: {
       version: '1.0.0',
-      title: 'Apinf API',
+      title: 'Admin API',
     },
   },
   tags: {

--- a/core/server/api.js
+++ b/core/server/api.js
@@ -20,14 +20,6 @@ ApiV1.swagger = {
     info: {
       version: '1.0.0',
       title: 'Apika API',
-      description: 'Apika REST API',
-      termsOfService: 'https://apika.digipalvelutehdas.fi/terms/',
-      contact: {
-        name: 'Apika team',
-      },
-      license: {
-        name: 'MIT',
-      },
     },
   },
   tags: {

--- a/core/server/api.js
+++ b/core/server/api.js
@@ -19,7 +19,7 @@ ApiV1.swagger = {
     swagger: '2.0',
     info: {
       version: '1.0.0',
-      title: 'Apika API',
+      title: 'Apinf API',
     },
   },
   tags: {


### PR DESCRIPTION
Closes #162 

# Changes
- Change api route to `/api`
- Remove hardcoded values from swagger definition
  - Apika specific language
  - Broken link to terms of service
- Make swagger fields more generic