### PR TITLE
Merge pull request #1990 from apinf/update-travis-ci-settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ services:
   - docker
 
 script:
-  - docker build -t apinf/platform:apika_develop .
+  - docker build -t apinf/platform:$DOCKER_TAG .
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker push apinf/platform:apika_develop
+  - docker push apinf/platform:$DOCKER_TAG


### PR DESCRIPTION
The target: Fix issue with Travis config, after merge APIKA code to APINF. Now both projects generate "apika_develop" Docker image.

Use ENV variable for flexible change docker tag name for APINF and APIKA with TravisCI builds.
From now we can change $DOCKER_TAG ENV variable in TravisCI settings.


https://github.com/apinf/platform/pull/1990