### PR TITLE
Fix Api grid home using apiCatalogGrid template

### DIFF
--- a/apis/client/latest/latest.html
+++ b/apis/client/latest/latest.html
@@ -4,11 +4,7 @@
   </h2>
   <hr class="primary">
   {{# if latestPublicApis }}
-    {{# each api in latestPublicApis }}
-      <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 col-xs-12">
-        {{> apiCard api=api }}
-      </div>
-    {{/ each }}
+    {{> apiCatalogGrid apis=latestPublicApis }}
   {{ else }}
   <i>
     {{_ "latestApiBackends_NotFound" }}


### PR DESCRIPTION
On the grid Apis on Homepage, the margin between the rows was missing. I solved using the same template apiCatalogGrid used also for Api Catalogs, Search Apis, Organization Profile.

